### PR TITLE
Put error message in output

### DIFF
--- a/lib/start-failed.js
+++ b/lib/start-failed.js
@@ -39,6 +39,7 @@ module.exports = function startFailed(err) {
     ${serverStartError.message}
     ${serverStartError.description}
     ${ErrorCommon.fileIssue}
+    ${Chalk.bold.red(err.message)}
 `;
 
   console.error(errDetail); // eslint-disable-line


### PR DESCRIPTION
The current error handler only shows a stack trace and not the error message from the actual error.

I see this when using Hoek.assert etc to pre-check on module load, this change will assist in knowing what the thrown error was.