### PR TITLE
23: option to regulate what electrode server shows on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ const config = {
 require("electrode-server")(config);
 ```
 
-However, for a more complex application, it's recommended that you use a config composer such as [electrode-confippet] to manage your app configuration.  
+However, for a more complex application, it's recommended that you use a config composer such as [electrode-confippet] to manage your app configuration.
 
 ## Configuration Options
 
@@ -62,7 +62,7 @@ All properties are optional (if not present, the default values shown below will
 
    * _default_
 
-```js    
+```js
 {
   server: {
     app: {
@@ -137,7 +137,26 @@ myConfig.listener = (emitter) => {
 });
 ```
 
-## electrode-confippet
+### logLevel
+
+You can control how much output the Electrode Server logs to the console by setting the `logLevel` property in the config to "info" (the default if this is not specified at all), "warn" or "error". A level of "warn" means only warning and error messages will be printed.
+
+```js
+{
+  electrode: {
+    suppressStartupBanner: true
+  }
+}
+```
+
+So, for example, to suppress the handy informational banner that is shown when the server starts up:
+```
+Hapi.js server running at http://mypc:4000
+```
+set the logLevel to "warn" or "error".
+
+
+ ## electrode-confippet
 
 To keep your environment specific configurations manageable, you can use [electrode-confippet].
 

--- a/lib/check-node-env.js
+++ b/lib/check-node-env.js
@@ -3,12 +3,14 @@
 const _ = require("lodash");
 const Chalk = require("chalk");
 
+const logger = require("./logger.js");
+
 function checkNodeEnv() {
   const allowed = ["development", "staging", "production", "test"];
 
   if (process.env.NODE_ENV && !_.includes(allowed, process.env.NODE_ENV)) {
     const msg = `Electrode Server Notice: NODE_ENV (${process.env.NODE_ENV}) should be empty or one of ${allowed}`; // eslint-disable-line
-    console.warn(`    ${Chalk.inverse.bold.yellow(msg)}`);  // eslint-disable-line
+    logger.warn(`    ${Chalk.inverse.bold.yellow(msg)}`);
   }
 }
 

--- a/lib/electrode-server.js
+++ b/lib/electrode-server.js
@@ -6,6 +6,7 @@ const _ = require("lodash");
 const Chalk = require("chalk");
 const Path = require("path");
 const checkNodeEnv = require("./check-node-env");
+const logger = require("./logger.js");
 const startFailed = require("./start-failed");
 const Confippet = require("electrode-confippet");
 const AsyncEventEmitter = require("async-eventemitter");
@@ -24,8 +25,8 @@ function showRegisterPluginsNote(timeout) {
   const next = Chalk.red("next()");
   return setTimeout(() =>
       /* eslint-disable */
-      console.log(Chalk.green(`
-Register plugins is taking a while - If this takes longer than 10 seconds, then 
+      logger.warn(Chalk.green(`
+Register plugins is taking a while - If this takes longer than 10 seconds, then
 double check your plugins to make sure each one calls ${next} at the end.
 
 Server will automatically abort after ${remain / 1000} seconds.
@@ -117,7 +118,7 @@ function startElectrodeServer(context) {
     return (new Promise((resolve, reject) => {
       server.register(plugins, (err) => {
         if (err) {
-          console.error("Register plugins failed", err); // eslint-disable-line
+          logger.error("Register plugins failed", err);
           reject(err instanceof Error ? err : new Error(err));
         } else {
           resolve();
@@ -143,7 +144,7 @@ function startElectrodeServer(context) {
 
   const logStarted = () => {
     _.each(server.connections, (conn) => {
-      console.log(Chalk.green(`\nHapi.js server running at ${conn.info.uri}\n`)); // eslint-disable-line
+      logger.info(Chalk.green(`\nHapi.js server running at ${conn.info.uri}\n`));
     });
   };
 
@@ -192,6 +193,9 @@ module.exports = function electrodeServer(appConfig, decors, callback) {
     };
 
     Confippet.util.merge(hapiServerConfig, context.config.server);
+
+    // Set the log level (if no config value set, then we log all)
+    logger.setLevel(context.config.electrode && context.config.electrode.logLevel);
 
     //
     // This will allow Hapi to make config available through

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,46 @@
+/* eslint-disable no-console */
+
+"use strict";
+
+const LEVELS = {
+  info: 10,
+  warn: 20,
+  error: 30
+};
+
+let level = LEVELS.info;
+
+const logger = {
+
+  setLevel(newLevel) {
+    const lowerLevel = (newLevel || "info").toLowerCase();
+    const numericLevel = LEVELS[lowerLevel];
+
+    if (!numericLevel) {
+      throw new Error(
+        `Log level must be one of ${Object.keys(LEVELS).join(", ")}. Received "${newLevel}".`);
+    }
+
+    level = numericLevel;
+  },
+
+  info(...message) {
+    if (level <= LEVELS.info) {
+      console.info(...message);
+    }
+  },
+
+  warn(...message) {
+    if (level <= LEVELS.warn) {
+      console.warn(...message);
+    }
+  },
+
+  error(...message) {
+    if (level <= LEVELS.error) {
+      console.error(...message);
+    }
+  }
+};
+
+module.exports = logger;

--- a/lib/start-failed.js
+++ b/lib/start-failed.js
@@ -2,6 +2,7 @@
 
 const Chalk = require("chalk");
 const ErrorCommon = require("./error-common");
+const logger = require("./logger.js");
 const Promise = require("bluebird");
 
 module.exports = function startFailed(err) {
@@ -42,7 +43,7 @@ module.exports = function startFailed(err) {
     ${Chalk.bold.red(err.message)}
 `;
 
-  console.error(errDetail); // eslint-disable-line
+  logger.error(errDetail);
 
   return Promise.reject(serverStartError);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,7 @@
   "name": "electrode-server",
   "version": "1.3.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "abbrev": {
       "version": "1.0.9",
@@ -3509,12 +3510,6 @@
       "dev": true,
       "optional": true
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3525,6 +3520,12 @@
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,7 +2,6 @@
   "name": "electrode-server",
   "version": "1.3.0",
   "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
     "abbrev": {
       "version": "1.0.9",
@@ -3510,6 +3509,12 @@
       "dev": true,
       "optional": true
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3520,12 +3525,6 @@
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",

--- a/test/spec/check-node-env.spec.js
+++ b/test/spec/check-node-env.spec.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const checkNodeEnv = require("../../lib/check-node-env.js");
+const logger = require("../../lib/logger.js");
 const Chai = require("chai");
 
 describe("process-env-abbr", function () {
@@ -33,14 +34,14 @@ describe("process-env-abbr", function () {
   });
 
   it("should print warning for unexpected NODE_ENV", function (done) {
-    const w = console.warn;
+    const w = logger.warn;
     let msg;
-    console.warn = (m) => {
+    logger.warn = (m) => {
       msg = m;
     };
     process.env.NODE_ENV = "undefined";
     checkNodeEnv();
-    console.warn = w;
+    logger.warn = w;
     Chai.expect(msg).includes("should be empty or one of");
     done();
   });

--- a/test/spec/electrode.spec.js
+++ b/test/spec/electrode.spec.js
@@ -285,4 +285,35 @@ describe("electrode-server", function () {
       });
   });
 
+  it("displays a startup banner at startup time", () => {
+    const i = console.info;
+    let msg;
+    console.info = (m) => {
+      msg = m;
+    };
+    return electrodeServer()
+      .then((server) => {
+        console.info = i;
+        assert.include(msg, "Hapi.js server running");
+        return stopServer(server);
+      });
+  });
+
+  it("displays no startup banner at startup time if logLevel is set to something other than info", () => {
+    const i = console.info;
+    let msg;
+    console.info = (m) => {
+      msg = m;
+    };
+    return electrodeServer({
+      electrode: {
+        logLevel: "warn"
+      }
+    })
+      .then((server) => {
+        console.info = i;
+        assert.isUndefined(msg);
+        return stopServer(server);
+      });
+  });
 });

--- a/test/spec/logger.spec.js
+++ b/test/spec/logger.spec.js
@@ -1,0 +1,113 @@
+"use strict";
+
+const Chai = require("chai");
+const logger = require("../../lib/logger.js");
+
+describe("logger", function () {
+
+  describe("setLevel()", () => {
+
+    it("throws an Error if it is passed an unknown level", () => {
+      Chai.expect(() => logger.setLevel("bogus"))
+        .to.throw("Log level must be one of info, warn, error. Received \"bogus\".");
+    });
+
+  });
+
+  describe("info()", () => {
+
+    it("logs an info message if the level is set to info", () => {
+      logger.setLevel("info");
+      let result;
+      console.info = (...values) => {
+        result = values;
+      };
+
+      logger.info(1, 2, 3);
+
+      Chai.expect(result).to.deep.equal([1, 2, 3]);
+    });
+
+    it("logs no info message if the level is set to warn", () => {
+      logger.setLevel("warn");
+      let result;
+      console.info = (...values) => {
+        result = values;
+      };
+
+      logger.info(1, 2, 3);
+
+      Chai.expect(result).to.be.undefined;
+    });
+
+  });
+
+  describe("warn()", () => {
+
+    it("logs a warn message if the level is set to info", () => {
+      logger.setLevel("info");
+      let result;
+      console.warn = (...values) => {
+        result = values;
+      };
+
+      logger.warn(1, 2, 3);
+
+      Chai.expect(result).to.deep.equal([1, 2, 3]);
+    });
+
+    it("logs a warn message if the level is set to warn", () => {
+      logger.setLevel("warn");
+      let result;
+      console.warn = (...values) => {
+        result = values;
+      };
+
+      logger.warn(1, 2, 3);
+
+      Chai.expect(result).to.deep.equal([1, 2, 3]);
+    });
+
+    it("logs no warn message if the level is set to error", () => {
+      logger.setLevel("error");
+      let result;
+      console.warn = (...values) => {
+        result = values;
+      };
+
+      logger.warn(1, 2, 3);
+
+      Chai.expect(result).to.be.undefined;
+    });
+
+  });
+
+  describe("error()", () => {
+
+    it("logs an error message if the level is set to warn", () => {
+      logger.setLevel("warn");
+      let result;
+      console.error = (...values) => {
+        result = values;
+      };
+
+      logger.error(1, 2, 3);
+
+      Chai.expect(result).to.deep.equal([1, 2, 3]);
+    });
+
+    it("logs an error message if the level is set to error", () => {
+      logger.setLevel("error");
+      let result;
+      console.error = (...values) => {
+        result = values;
+      };
+
+      logger.error(1, 2, 3);
+
+      Chai.expect(result).to.deep.equal([1, 2, 3]);
+    });
+
+  });
+
+});


### PR DESCRIPTION
This is a solution to https://github.com/electrode-io/electrode-server/issues/23

### Problem
When running lots of integration-type tests using the electrode server, we end up with a lot of "noise" in our logs with the "Hapi.js server running" message that gets printed automatically.

### Solution
This adds an optional configuration value called `logLevel`
```
electrode: {
  logLevel: "warn"
}
```
which, if set to "warn" or "error", will cause Electrode Server to not display its startup banner.

The more general point is that `logLevel` can be set to "info", "warn" or "error", and when set to the specified level, Electrode Server will only write out console messages that are of that level of severity or higher.  The startup banner is an "info" message, while the failure to register plugins is an error.

This includes the code change, a doc change, and a test to validate it works.

### Note
This was originally submitted and discussed at https://github.com/electrode-io/electrode-server/pull/24  . But I got a work and personal account tangled up and ended up deleting that branch.  So, see that pull request to get a historical context on this change.