### PR TITLE
stop using bluebird

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-  - v8
   - v10
+  - v12
+  - v13
 script: fun test
 notifications:
   email:

--- a/lib/electrode-server.js
+++ b/lib/electrode-server.js
@@ -3,7 +3,6 @@
 /* eslint-disable no-magic-numbers, prefer-template */
 
 const assert = require("assert");
-const Promise = require("bluebird");
 const Hapi = require("@hapi/hapi");
 const _ = require("lodash");
 const Chalk = require("chalk");
@@ -14,6 +13,7 @@ const startFailed = require("./start-failed");
 const Confippet = require("electrode-confippet");
 const AsyncEventEmitter = require("async-eventemitter");
 const requireAt = require("require-at");
+const xaa = require("xaa");
 
 const MS_PER_SEC = 1000;
 
@@ -31,13 +31,13 @@ function emitEvent(context, event) {
   });
 
   if (timeout) {
-    promise = promise.timeout(timeout);
+    promise = xaa.runTimeout(promise, timeout);
   }
 
   return promise.catch(err => {
     err.timeout = timeout;
     err.event = event;
-    if (err instanceof Promise.TimeoutError) {
+    if (err instanceof xaa.TimeoutError) {
       err.message = `timeout waiting for event '${event}' handler`;
       err.code = "XEVENT_TIMEOUT";
     } else {
@@ -146,7 +146,8 @@ function convertPluginsToArray(plugins) {
         fromPath = p.requireFromPath = "";
       }
 
-      return Promise.try(() => xrequire(name))
+      return xaa
+        .wrap(() => xrequire(name))
         .catch(error => {
           error.message = `Failed loading module ${pluginMod.name}${fromPath}: ${error.message}`;
           throw error;
@@ -176,7 +177,7 @@ function convertPluginsToArray(plugins) {
         });
     };
 
-    return Promise.try(doRequire);
+    return xaa.wrap(doRequire);
   };
 
   const num = x => {
@@ -202,7 +203,7 @@ function convertPluginsToArray(plugins) {
       .value();
 
   // convert plugins object to array and check each one if it has a module to load.
-  return Promise.try(pluginsArray).map(loadModule);
+  return xaa.wrap(pluginsArray).then(arr => xaa.map(arr, loadModule));
 }
 
 function startElectrodeServer(context) {
@@ -222,29 +223,31 @@ function startElectrodeServer(context) {
     const timeout = _.get(config, "electrode.registerPluginsTimeout", 5000);
     const registerState = {};
     const noteTimeout = showRegisterPluginsNote(registerState, timeout);
-    return Promise.each(plugins, plg => {
-      registerState.plugin = plg;
-      let registerPromise = Promise.resolve(server.register(plg));
-      if (shouldAutoAbort()) {
-        registerPromise = registerPromise.timeout(timeout);
-      }
-
-      return registerPromise.catch(err => {
-        if (!err || !err.hasOwnProperty("message")) {
-          err = new Error(err);
-        } else if (err instanceof Promise.TimeoutError) {
-          err.message = `timeout - did you return a resolved promise?`;
+    return xaa
+      .each(plugins, plg => {
+        registerState.plugin = plg;
+        let registerPromise = Promise.resolve(server.register(plg));
+        if (shouldAutoAbort()) {
+          registerPromise = xaa.runTimeout(registerPromise, timeout);
         }
 
-        err.code = "XPLUGIN_FAILED";
-        err.plugin = plg;
-        err.method = registerMethod(plg);
+        return registerPromise.catch(err => {
+          if (!err || !err.hasOwnProperty("message")) {
+            err = new Error(err);
+          } else if (err instanceof xaa.TimeoutError) {
+            err.message = `timeout - did you return a resolved promise?`;
+          }
 
-        throw err;
+          err.code = "XPLUGIN_FAILED";
+          err.plugin = plg;
+          err.method = registerMethod(plg);
+
+          throw err;
+        });
+      })
+      .finally(() => {
+        clearTimeout(noteTimeout);
       });
-    }).finally(() => {
-      clearTimeout(noteTimeout);
-    });
   };
 
   let started = false;
@@ -254,24 +257,20 @@ function startElectrodeServer(context) {
 
   return emitEvent(context, "server-created")
     .then(() => convertPluginsToArray(config.plugins))
-    .tap(plugins => {
+    .then(plugins => {
       context.plugins = plugins;
-      return emitEvent(context, "plugins-sorted");
+      return emitEvent(context, "plugins-sorted").then(() => plugins);
     })
     .then(registerPlugins)
-    .tap(() => {
-      return emitEvent(context, "plugins-registered");
-    })
+    .then(x => emitEvent(context, "plugins-registered").then(() => x))
     .then(() => server.start())
-    .tap(() => {
+    .then(x => {
       started = true;
-      return emitEvent(context, "server-started");
+      return emitEvent(context, "server-started").then(() => x);
     })
     .then(logStarted)
     .then(() => server)
-    .tap(() => {
-      return emitEvent(context, "complete");
-    })
+    .then(x => emitEvent(context, "complete").then(() => x))
     .catch(err => {
       return Promise.resolve(started && server.stop()).finally(() => startFailed(err));
     });
@@ -323,19 +322,21 @@ module.exports = function electrodeServer(appConfig = {}, decors, callback) {
   };
 
   const start = context =>
-    Promise.try(() => new Hapi.Server(makeHapiServerConfig(context))).then(server => {
-      context.server = server;
+    xaa
+      .wrap(() => new Hapi.Server(makeHapiServerConfig(context)))
+      .then(server => {
+        context.server = server;
 
-      //
-      // Make config available in server.app.config, in addition to
-      // server.settings.app.config
-      //
-      server.app.config = server.settings.app.config;
+        //
+        // Make config available in server.app.config, in addition to
+        // server.settings.app.config
+        //
+        server.app.config = server.settings.app.config;
 
-      // Start server
+        // Start server
 
-      return startElectrodeServer(context);
-    });
+        return startElectrodeServer(context);
+      });
 
   const applyDecorConfigs = context => {
     // load internal defaults
@@ -378,10 +379,10 @@ module.exports = function electrodeServer(appConfig = {}, decors, callback) {
   };
 
   const promise = Promise.resolve({})
-    .tap(setListeners)
-    .tap(applyDecorConfigs)
-    .tap(context => emitEvent(context, "config-composed"))
+    .then(setListeners)
+    .then(applyDecorConfigs)
+    .then(context => emitEvent(context, "config-composed").then(() => context))
     .then(start);
 
-  return callback ? promise.nodeify(callback) : promise;
+  return callback ? promise.then(r => callback(null, r), callback) : promise;
 };

--- a/lib/start-failed.js
+++ b/lib/start-failed.js
@@ -5,16 +5,13 @@
 const Chalk = require("chalk");
 const ErrorCommon = require("./error-common");
 const logger = require("./logger.js");
-const Promise = require("bluebird");
 const _ = require("lodash");
 
 module.exports = function startFailed(err) {
   const errors = {
     EADDRINUSE: () => {
       return {
-        reason: `the network port (${
-          err.port
-        }) is already in use but your server is trying to listen to it`,
+        reason: `the network port (${err.port}) is already in use but your server is trying to listen to it`,
         resolution: `
       Ensure no other processes are running on this port, or change the port
       your server should listen on.

--- a/package.json
+++ b/package.json
@@ -51,11 +51,11 @@
   "dependencies": {
     "@hapi/hapi": "^18.3.2",
     "async-eventemitter": "^0.2.2",
-    "bluebird": ">= 2.10.0 <= 3.x.x",
     "chalk": "^2.4.2",
     "electrode-confippet": "^1.2.10",
     "lodash": "^4.17.11",
-    "require-at": "^1.0.1"
+    "require-at": "^1.0.1",
+    "xaa": "^1.1.2"
   },
   "devDependencies": {
     "@hapi/inert": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "electrode-confippet": "^1.2.10",
     "lodash": "^4.17.11",
     "require-at": "^1.0.1",
-    "xaa": "^1.1.2"
+    "xaa": "^1.1.4"
   },
   "devDependencies": {
     "@hapi/inert": "^5.2.2",

--- a/test/spec/electrode.spec.js
+++ b/test/spec/electrode.spec.js
@@ -5,8 +5,8 @@ const electrodeServer = require("../..");
 const assert = require("chai").assert;
 const _ = require("lodash");
 const request = require("superagent");
-const Promise = require("bluebird");
 const { asyncVerify, expectError } = require("run-verify");
+const xaa = require("xaa");
 
 const HTTP_404 = 404;
 
@@ -328,10 +328,13 @@ describe("electrode-server", function() {
     const save = process.execArgv;
     process.execArgv = [mode];
     const register = () => {
-      return new Promise(() => {
-        // never resolves or rejects
-      })
-        .timeout(200)
+      return xaa
+        .runTimeout(
+          new Promise(() => {
+            // never resolves or rejects
+          }),
+          200
+        )
         .catch(() => Promise.reject(new Error("--- test timeout ---")))
         .then(() => Promise.reject(new Error("boom")));
     };


### PR DESCRIPTION
node.js 10 with its native promise and async/await has match and likely exceed bluebird in performance and efficiency.  bluebird's author also acknowledged this.

While bluebird still has some hugely nice and useful APIs, it makes sense for us to move toward native promise and async/await now.

This PR remove using bluebird from electrode-server, replace some of the APIs implemented on top of async/await and native promise, in a module `xaa`.