### PR TITLE
Default connection keep-alive timeout to 60 seconds from Node's 5sec

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,18 @@ Default is just empty object:
 }
 ```
 
+### `keepAliveTimeout` (milliseconds)
+
+NodeJS defaults keep-alive timeout to 5 seconds. `electrode-server` defaults to 60 seconds. If you want a custom timeout, use the `keepAliveTimeout` option (in milliseconds).
+
+```json
+{
+  "electrode": {
+    "keepAliveTimeout": 60000
+  }
+}
+```
+
 ### `listener` (function)
 
 - A function to install event listeners for the electrode server startup lifecycle.

--- a/lib/electrode-server.js
+++ b/lib/electrode-server.js
@@ -210,7 +210,11 @@ function startElectrodeServer(context) {
     });
     // Set default keep alive to 60 seconds; NodeJS's 5 sec causes 503s for some gateways
     _.each(server.connections, conn => {
-      conn.listener.keepAliveTimeout = DEFAULT_KEEPALIVE;
+      conn.listener.keepAliveTimeout = _.get(
+        config,
+        "electrode.keepAliveTimeout",
+        DEFAULT_KEEPALIVE
+      );
     });
   };
 

--- a/lib/electrode-server.js
+++ b/lib/electrode-server.js
@@ -16,6 +16,7 @@ const AsyncEventEmitter = require("async-eventemitter");
 const requireAt = require("require-at");
 
 const MS_PER_SEC = 1000;
+const DEFAULT_KEEPALIVE = 60000;
 
 function emitEvent(context, event) {
   const timeout = _.get(context, "config.electrode.eventTimeout");
@@ -206,6 +207,10 @@ function startElectrodeServer(context) {
         conn.labels.push(name);
       }
       server.connection(conn);
+    });
+    // Set default keep alive to 60 seconds; NodeJS's 5 sec causes 503s for some gateways
+    _.each(server.connections, conn => {
+      conn.listener.keepAliveTimeout = DEFAULT_KEEPALIVE;
     });
   };
 

--- a/test/spec/electrode.spec.js
+++ b/test/spec/electrode.spec.js
@@ -114,12 +114,21 @@ describe("electrode-server", function() {
   });
 
   it("should set keepalive to 60 seconds", function() {
-    return electrodeServer()
-      .then(server => {
-        expect(server.listener.keepAliveTimeout).eq(60000);
-        return server;
-      })
-      .then(stopServer);
+    return electrodeServer().then(server => {
+      expect(server.listener.keepAliveTimeout).eq(60000);
+      stopServer(server);
+    });
+  });
+
+  it("can configure keep-alive timeout", function() {
+    return electrodeServer({
+      electrode: {
+        keepAliveTimeout: 6001
+      }
+    }).then(server => {
+      expect(server.listener.keepAliveTimeout).eq(6001);
+      stopServer(server);
+    });
   });
 
   it("multiple listeners should all set keepalive to 60 seconds", function() {

--- a/test/spec/electrode.spec.js
+++ b/test/spec/electrode.spec.js
@@ -113,6 +113,31 @@ describe("electrode-server", function() {
       });
   });
 
+  it("should set keepalive to 60 seconds", function() {
+    return electrodeServer()
+      .then(server => {
+        expect(server.listener.keepAliveTimeout).eq(60000);
+        return server;
+      })
+      .then(stopServer);
+  });
+
+  it("multiple listeners should all set keepalive to 60 seconds", function() {
+    return electrodeServer({
+      connections: {
+        default: { port: 8000 },
+        two: { port: 8001 }
+      }
+    })
+      .then(server => {
+        expect(server.connections.length).eq(2);
+        expect(server.connections[0].listener.keepAliveTimeout).eq(60000);
+        expect(server.connections[1].listener.keepAliveTimeout).eq(60000);
+        return server;
+      })
+      .then(stopServer);
+  });
+
   it("should fail if plugins.requireFromPath is not string", function() {
     let error;
     return electrodeServer({ electrode: { logLevel: "none" }, plugins: { requireFromPath: {} } })


### PR DESCRIPTION
5 second timeout might cause some gateways to timeout the connection and cause 503s. 60s is more practical.