### PR TITLE
Default connection keep-alive timeout to 60 seconds from Node's 5sec

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,9 @@ NodeJS defaults to 5 seconds keep-alive timeout. `electrode-server` defaults to 
 
 ```json
 {
-  "keepAliveTimeout": 60000
+  "electrode": {
+    "keepAliveTimeout": 60000
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,16 @@ To enable http2, set `http2.enable` to true. All options are passed to [`createS
 }
 ```
 
+### `keepAliveTimeout` (integer)
+
+NodeJS defaults to 5 seconds keep-alive timeout. `electrode-server` defaults to 60 seconds timeout. If you want a custom timeout, use the `keepAliveTimeout` option (in milliseconds).
+
+```json
+{
+  "keepAliveTimeout": 60000
+}
+```
+
 ### logLevel
 
 You can control how much output the Electrode Server logs to the console by setting the `logLevel`.

--- a/lib/electrode-server.js
+++ b/lib/electrode-server.js
@@ -18,6 +18,7 @@ const requireAt = require("require-at");
 const { PLUGIN_KEY } = require("./symbols");
 
 const MS_PER_SEC = 1000;
+const DEFAULT_KEEPALIVE_TIMEOUT = 60000;
 
 function emitEvent(context, event) {
   const timeout = _.get(context, "config.electrode.eventTimeout");
@@ -359,6 +360,7 @@ module.exports = function electrodeServer(appConfig, decors, callback) {
   const start = context =>
     Promise.try(() => new Hapi.Server(makeHapiServerConfig(context))).then(server => {
       context.server = server;
+      server.listener.keepAliveTimeout = DEFAULT_KEEPALIVE_TIMEOUT;
 
       //
       // Make config available in server.app.config, in addition to

--- a/lib/electrode-server.js
+++ b/lib/electrode-server.js
@@ -360,7 +360,11 @@ module.exports = function electrodeServer(appConfig, decors, callback) {
   const start = context =>
     Promise.try(() => new Hapi.Server(makeHapiServerConfig(context))).then(server => {
       context.server = server;
-      server.listener.keepAliveTimeout = DEFAULT_KEEPALIVE_TIMEOUT;
+      server.listener.keepAliveTimeout = _.get(
+        context,
+        "config.keepAliveTimeout",
+        DEFAULT_KEEPALIVE_TIMEOUT
+      );
 
       //
       // Make config available in server.app.config, in addition to

--- a/lib/electrode-server.js
+++ b/lib/electrode-server.js
@@ -362,7 +362,7 @@ module.exports = function electrodeServer(appConfig, decors, callback) {
       context.server = server;
       server.listener.keepAliveTimeout = _.get(
         context,
-        "config.keepAliveTimeout",
+        "config.electrode.keepAliveTimeout",
         DEFAULT_KEEPALIVE_TIMEOUT
       );
 

--- a/test/spec/electrode.spec.js
+++ b/test/spec/electrode.spec.js
@@ -98,6 +98,15 @@ describe("electrode-server", function() {
     });
   });
 
+  it("can specify custom keepalive timeout in config", function() {
+    return electrodeServer({
+      keepAliveTimeout: 6001
+    }).then(server => {
+      expect(server.listener.keepAliveTimeout).eq(6001);
+      stopServer(server);
+    });
+  });
+
   it("should pass plugin options", () => {
     const options = {
       test: "foo"

--- a/test/spec/electrode.spec.js
+++ b/test/spec/electrode.spec.js
@@ -100,7 +100,9 @@ describe("electrode-server", function() {
 
   it("can specify custom keepalive timeout in config", function() {
     return electrodeServer({
-      keepAliveTimeout: 6001
+      electrode: {
+        keepAliveTimeout: 6001
+      }
     }).then(server => {
       expect(server.listener.keepAliveTimeout).eq(6001);
       stopServer(server);

--- a/test/spec/electrode.spec.js
+++ b/test/spec/electrode.spec.js
@@ -91,6 +91,13 @@ describe("electrode-server", function() {
     });
   });
 
+  it("should default keepalive timeout to 60 seconds", function() {
+    return electrodeServer().then(server => {
+      expect(server.listener.keepAliveTimeout).eq(60000);
+      stopServer(server);
+    });
+  });
+
   it("should pass plugin options", () => {
     const options = {
       test: "foo"


### PR DESCRIPTION
5 second timeout might cause some gateways to timeout the connection and cause 503s. 60s is more practical.