### PR TITLE
Default connection keep-alive timeout to 60 seconds from Node's 5sec

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,18 @@ To enable http2, set `http2.enable` to true. All options are passed to [`createS
 }
 ```
 
+### `keepAliveTimeout` (integer)
+
+NodeJS defaults to 5 seconds keep-alive timeout. `electrode-server` defaults to 60 seconds timeout. If you want a custom timeout, use the `keepAliveTimeout` option (in milliseconds).
+
+```json
+{
+  "electrode": {
+    "keepAliveTimeout": 60000
+  }
+}
+```
+
 ### logLevel
 
 You can control how much output the Electrode Server logs to the console by setting the `logLevel`.
@@ -419,7 +431,7 @@ Hit `http://localhost:9000`
 ### Publishing
 
 - Require access to npmjs.org to publish this package.
-- Run `npm version` to update the version.  Commit with tags
+- Run `npm version` to update the version. Commit with tags
 - Run `npm publish` to publish
 - Update CHANGELOG.md
 

--- a/lib/electrode-server.js
+++ b/lib/electrode-server.js
@@ -18,6 +18,7 @@ const xaa = require("xaa");
 const { PLUGIN_KEY } = require("./symbols");
 
 const MS_PER_SEC = 1000;
+const DEFAULT_KEEPALIVE_TIMEOUT = 60000;
 
 function emitEvent(context, event) {
   const timeout = _.get(context, "config.electrode.eventTimeout");
@@ -366,6 +367,12 @@ module.exports = function electrodeServer(appConfig = {}, decors, callback) {
         // server.settings.app.config
         //
         server.app.config = server.settings.app.config;
+
+        server.listener.keepAliveTimeout = _.get(
+          context,
+          "config.electrode.keepAliveTimeout",
+          DEFAULT_KEEPALIVE_TIMEOUT
+        );
 
         // Start server
 

--- a/test/spec/electrode.spec.js
+++ b/test/spec/electrode.spec.js
@@ -79,6 +79,24 @@ describe("electrode-server", function() {
       .then();
   });
 
+  it("should default keepalive timeout to 60 seconds", function() {
+    return electrodeServer().then(server => {
+      expect(server.listener.keepAliveTimeout).eq(60000);
+      stopServer(server);
+    });
+  });
+
+  it("can specify custom keepalive timeout in config", function() {
+    return electrodeServer({
+      electrode: {
+        keepAliveTimeout: 6001
+      }
+    }).then(server => {
+      expect(server.listener.keepAliveTimeout).eq(6001);
+      stopServer(server);
+    });
+  });
+
   it("should make default connections the connection", function() {
     return electrodeServer({
       connections: {


### PR DESCRIPTION
5 second timeout might cause some gateways to timeout the connection and cause 503s. 60s is more practical.